### PR TITLE
Create Diameter of a Binary Tree

### DIFF
--- a/Diameter of a Binary Tree
+++ b/Diameter of a Binary Tree
@@ -1,0 +1,109 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+struct Node {
+    int data;
+    struct Node* left;
+    struct Node* right;
+};
+Node* newNode(int val) {
+    Node* temp = new Node;
+    temp->data = val;
+    temp->left = NULL;
+    temp->right = NULL;
+    return temp;
+}
+Node* buildTree(string str) {
+    if (str.length() == 0 || str[0] == 'N') return NULL;
+
+    vector<string> ip;
+
+    istringstream iss(str);
+    for (string str; iss >> str;) ip.push_back(str);
+
+    Node* root = newNode(stoi(ip[0]));
+
+    queue<Node*> queue;
+    queue.push(root);
+
+    int i = 1;
+    while (!queue.empty() && i < ip.size()) {
+
+        Node* currNode = queue.front();
+        queue.pop();
+
+        string currVal = ip[i];
+
+        if (currVal != "N") {
+
+            currNode->left = newNode(stoi(currVal));
+
+            queue.push(currNode->left);
+        }
+        i++;
+        if (i >= ip.size()) break;
+        currVal = ip[i];
+
+        if (currVal != "N") {
+
+            currNode->right = newNode(stoi(currVal));
+
+            queue.push(currNode->right);
+        }
+        i++;
+    }
+
+    return root;
+}
+
+
+struct Node
+{
+    int data;
+    struct Node* left;
+    struct Node* right;
+
+    Node(int x){
+        data = x;
+        left = right = NULL;
+    }
+}; 
+
+class Solution {
+    int cal(Node* node, int* height)
+    {
+        if(node==NULL)
+        {
+            *height=0;
+            return 0;
+        }
+        int lh=0,rh=0;
+        int ldia=cal(node->left,&lh);
+        int rdia=cal(node->right,&rh);
+         
+        *height=max(lh,rh)+1;
+        return max(lh+rh+1,max(ldia,rdia));
+    }
+    
+    
+  public:
+    int diameter(Node* root) {
+        if(root==NULL)
+        return 0;
+        int height=0;
+        return cal(root,&height);
+    }
+};
+
+int main() {
+    int t;
+    scanf("%d\n", &t);
+    while (t--) {
+        string s;
+        getline(cin, s);
+        Node* root = buildTree(s);
+        Solution ob;
+        cout << ob.diameter(root) << endl;
+    }
+    return 0;
+}


### PR DESCRIPTION
The diameter of a tree (sometimes called the width) is the number of nodes on the longest path between two end nodes. The diagram below shows two trees each with diameter nine, the leaves that form the ends of the longest path are shaded (note that there is more than one path in each tree of length nine, but no path longer than nine nodes).